### PR TITLE
feat: better useRouter

### DIFF
--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -53,57 +53,57 @@ function warpPromiseOptions<T = any>(opts: T, resolve: Function, reject: Functio
   };
 }
 
+function navigate(options: UniNamespace.NavigateToOptions): Promise<any> {
+  return new Promise((resolve, reject) => {
+    // 先尝试能否切换 tabbar
+    uni.switchTab(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  }).catch(() => {
+    // 失败再尝试跳转 navigateTo
+    return new Promise((resolve, reject) => {
+      uni.navigateTo(
+        warpPromiseOptions(options, resolve, reject),
+      );
+    });
+  });
+}
+
+function redirect(options: UniNamespace.RedirectToOptions): Promise<any> {
+  return new Promise((resolve, reject) => {
+    // 先尝试能否切换 tabbar
+    uni.switchTab(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  }).catch(() => {
+    // 失败再尝试跳转 redirectTo
+    return new Promise((resolve, reject) => {
+      uni.redirectTo(
+        warpPromiseOptions(options, resolve, reject),
+      );
+    });
+  });
+}
+
+function reLaunch(options: UniNamespace.ReLaunchOptions): Promise<any> {
+  return new Promise((resolve, reject) => {
+    uni.reLaunch(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  });
+}
+
+function back(options: UniNamespace.NavigateBackOptions = { delta: 1 }): Promise<any> {
+  return new Promise((resolve, reject) => {
+    uni.navigateBack(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  });
+}
+
 /** 获取路由信息 */
 export function useRouter() {
   initIfNotInited();
-
-  function navigate(options: UniNamespace.NavigateToOptions): Promise<any> {
-    return new Promise((resolve, reject) => {
-      // 先尝试能否切换 tabbar
-      uni.switchTab(
-        warpPromiseOptions(options, resolve, reject),
-      );
-    }).catch(() => {
-      // 失败再尝试跳转 navigateTo
-      return new Promise((resolve, reject) => {
-        uni.navigateTo(
-          warpPromiseOptions(options, resolve, reject),
-        );
-      });
-    });
-  }
-
-  function redirect(options: UniNamespace.RedirectToOptions): Promise<any> {
-    return new Promise((resolve, reject) => {
-      // 先尝试能否切换 tabbar
-      uni.switchTab(
-        warpPromiseOptions(options, resolve, reject),
-      );
-    }).catch(() => {
-      // 失败再尝试跳转 redirectTo
-      return new Promise((resolve, reject) => {
-        uni.redirectTo(
-          warpPromiseOptions(options, resolve, reject),
-        );
-      });
-    });
-  }
-
-  function reLaunch(options: UniNamespace.ReLaunchOptions): Promise<any> {
-    return new Promise((resolve, reject) => {
-      uni.reLaunch(
-        warpPromiseOptions(options, resolve, reject),
-      );
-    });
-  }
-
-  function back(options: UniNamespace.NavigateBackOptions = { delta: 1 }): Promise<any> {
-    return new Promise((resolve, reject) => {
-      uni.navigateBack(
-        warpPromiseOptions(options, resolve, reject),
-      );
-    });
-  }
 
   return {
     /** 获取当前页面栈信息 */

--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -1,34 +1,132 @@
 import { ref, computed } from 'vue';
 
+/** 获取当前页面栈信息 */
+const pages = ref(getCurrentPages());
+
+/** 获取当前页信息 */
+// at is not supported
+const currentPage = computed(() => pages.value?.[pages.value.length - 1]);
+/** 获取前一页信息 */
+const prevPage = computed(() =>
+  pages.value.length > 1 ? pages.value[pages.value.length - 2] : pages.value?.[pages.value.length - 1],
+);
+
+/** 获取当前页路由信息 */
+const currentRoute = computed(() => currentPage.value?.route || '/');
+/** 获取前一页路由信息 */
+const prevRoute = computed(() => prevPage.value?.route);
+
+let isInited = false;
+
+function initIfNotInited() {
+  if (isInited) {
+    return;
+  }
+
+  function refreshCurrentPages() {
+    pages.value = getCurrentPages();
+  }
+
+  uni.addInterceptor('navigateTo', { complete: refreshCurrentPages });
+  uni.addInterceptor('redirectTo', { complete: refreshCurrentPages });
+  uni.addInterceptor('reLaunch', { complete: refreshCurrentPages });
+  uni.addInterceptor('switchTab', { complete: refreshCurrentPages });
+  uni.addInterceptor('navigateBack', { complete: refreshCurrentPages });
+
+  refreshCurrentPages();
+
+  isInited = true;
+}
+
+function warpPromiseOptions<T = any>(opts: T, resolve: Function, reject: Function) {
+  let { fail, success, complete } = opts as any;
+
+  fail = fail || ((err: any) => err);
+  success = success || ((res: any) => res);
+  complete = complete || (() => { });
+
+  return {
+    ...opts,
+    success: (res: any) => resolve(success(res)),
+    fail: (err: any) => reject(fail(err)),
+    complete,
+  };
+}
+
 /** 获取路由信息 */
 export function useRouter() {
-  /** 获取当前页面栈信息 */
-  const pages = ref(getCurrentPages());
-  const pagesLength = computed(() => pages.value.length);
+  initIfNotInited();
 
-  /** 获取当前页信息 */
-  // at is not supported
-  const page = computed(() => pages.value[pagesLength.value - 1]);
-  /** 获取前一页信息 */
-  const prevPage = computed(() =>
-    pagesLength.value > 1 ? pages.value[pagesLength.value - 2] : undefined,
-  );
+  function navigate(options: UniNamespace.NavigateToOptions): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // 先尝试能否切换 tabbar
+      uni.switchTab(
+        warpPromiseOptions(options, resolve, reject),
+      );
+    }).catch(() => {
+      // 失败再尝试跳转 navigateTo
+      return new Promise((resolve, reject) => {
+        uni.navigateTo(
+          warpPromiseOptions(options, resolve, reject),
+        );
+      });
+    });
+  }
 
-  /** 获取当前页路由信息 */
-  const route = computed(() => page.value?.route);
-  /** 获取前一页路由信息 */
-  const prevRoute = computed(() => prevPage.value?.route);
+  function redirect(options: UniNamespace.RedirectToOptions): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // 先尝试能否切换 tabbar
+      uni.switchTab(
+        warpPromiseOptions(options, resolve, reject),
+      );
+    }).catch(() => {
+      // 失败再尝试跳转 redirectTo
+      return new Promise((resolve, reject) => {
+        uni.redirectTo(
+          warpPromiseOptions(options, resolve, reject),
+        );
+      });
+    });
+  }
+
+  function reLaunch(options: UniNamespace.ReLaunchOptions): Promise<any> {
+    return new Promise((resolve, reject) => {
+      uni.reLaunch(
+        warpPromiseOptions(options, resolve, reject),
+      );
+    });
+  }
+
+  function back(options: UniNamespace.NavigateBackOptions = { delta: 1 }): Promise<any> {
+    return new Promise((resolve, reject) => {
+      uni.navigateBack(
+        warpPromiseOptions(options, resolve, reject),
+      );
+    });
+  }
 
   return {
     /** 获取当前页面栈信息 */
     pages,
     /** 获取当前页信息 */
-    page,
+    currentPage,
+    /** @deprecated 弃用，请使用 currentPage */
+    page: currentPage,
+    /** 获取当前页路由信息 */
+    currentRoute,
+    /** @deprecated 弃用，请使用 currentRoute */
+    route: currentRoute,
     /** 获取前一页信息 */
     prevPage,
-    /** 获取当前页路由信息 */
-    route,
     /** 获取前一页路由信息 */
     prevRoute,
+    /** 路由跳转，如果是 tabbar 页面则执行 switchTab */
+    navigate,
+    /** 路由重定向，会替换当前页面，如果是 tabbar 页面则执行 switchTab */
+    redirect,
+    /** 重定向，并清空当前页面栈 */
+    reLaunch,
+    /** 后退 */
+    back,
   };
 }


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

1. 去除每次 `useRouter` 都新建对象的副作用。
2. 加入路由跳转的函数封装。无须再区分 tabbar 路由和页面路由。
3. 为了消歧义，将 page 和 route 改为 currentPage 和 currentRoute （请确认是否需要修改 @ModyQyW ）
4. route 属性有歧义，容易误解为和vue router 一样的 route，但在uniapp里仅仅是个 url，请确认是否应该修改？ @ModyQyW 

@Ares-Chang 这个简化版的 useRouter 应该已经足够使用了吧？

