### PR TITLE
feat: stronger useRouter

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -4,6 +4,9 @@ export default defineBuildConfig({
   entries: ['./src/index'],
   clean: true,
   declaration: true,
+  externals:[
+    '@dcloudio/uni-cli-shared',
+  ],
   rollup: {
     emitCJS: true,
     esbuild: {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@commitlint/cli": "^18.4.4",
     "@commitlint/config-conventional": "^18.4.4",
     "@commitlint/prompt": "^18.4.4",
-    "@dcloudio/uni-cli-shared": "3.0.0-3090920231225001",
+    "@dcloudio/uni-cli-shared": "^3.0.0-3090920231225001",
     "@modyqyw/fabric": "^9.0.6",
     "@tsconfig/node18": "^18.2.2",
     "@types/node": "^20.11.0",

--- a/playground/package.json
+++ b/playground/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-3090920231225001",
     "@dcloudio/uni-app-plus": "3.0.0-3090920231225001",
-    "@dcloudio/uni-cli-shared": "3.0.0-3090920231225001",
     "@dcloudio/uni-components": "3.0.0-3090920231225001",
     "@dcloudio/uni-h5": "3.0.0-3090920231225001",
     "@dcloudio/uni-mp-alipay": "3.0.0-3090920231225001",

--- a/playground/package.json
+++ b/playground/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-3090920231225001",
     "@dcloudio/uni-app-plus": "3.0.0-3090920231225001",
+    "@dcloudio/uni-cli-shared": "3.0.0-3090920231225001",
     "@dcloudio/uni-components": "3.0.0-3090920231225001",
     "@dcloudio/uni-h5": "3.0.0-3090920231225001",
     "@dcloudio/uni-mp-alipay": "3.0.0-3090920231225001",

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,3 +7,9 @@ export type MaybeRef<T> = T | Ref<T>;
 export type MaybeRefOrGetter<T> = MaybeRef<T> | (() => T);
 
 export type MaybeComputedRef<T> = MaybeRefOrGetter<T>;
+
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+
+export type RequiredProperty<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+export type RequiredOnly<T, K extends keyof T> = RequiredProperty<Partial<T>, K>;

--- a/src/useRoute/index.ts
+++ b/src/useRoute/index.ts
@@ -1,6 +1,10 @@
 import { useRouter } from '../useRouter';
 
-/** 获取当前页路由信息 */
+/** 
+ * 获取当前页路由信息
+ * 
+ * @deprecated use `useRouter().currentUrl` instead
+ */
 export function useRoute() {
   const { route } = useRouter();
   return route;

--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -1,34 +1,235 @@
 import { ref, computed } from 'vue';
+import { pathResolve } from 'src/utils';
+import type { AppJson } from '@dcloudio/uni-cli-shared'
+import type { RequiredOnly } from '../types'
+import { onBackPress } from '@dcloudio/uni-app';
 
-/** 获取路由信息 */
-export function useRouter() {
-  /** 获取当前页面栈信息 */
-  const pages = ref(getCurrentPages());
-  const pagesLength = computed(() => pages.value.length);
+/** 获取当前页面栈信息 */
+const pages = ref(getCurrentPages());
+const pageLength = computed(() => pages.value.length); // 使用 computed 可触发依赖项更新
 
-  /** 获取当前页信息 */
-  // at is not supported
-  const page = computed(() => pages.value[pagesLength.value - 1]);
-  /** 获取前一页信息 */
-  const prevPage = computed(() =>
-    pagesLength.value > 1 ? pages.value[pagesLength.value - 2] : undefined,
-  );
+/** 获取当前页信息 */
+// at is not supported
+const current = computed(() => pages.value?.[pageLength.value - 1]);
+/** 获取前一页信息 */
+const prev = computed(() =>
+  pageLength.value > 1 ? pages.value[pageLength.value - 2] : pages.value?.[pageLength.value - 1],
+);
 
-  /** 获取当前页路由信息 */
-  const route = computed(() => page.value?.route);
-  /** 获取前一页路由信息 */
-  const prevRoute = computed(() => prevPage.value?.route);
+/** 获取当前页路由信息 */
+const currentUrl = computed(() => current.value?.route || '/');
+/** 获取前一页路由信息 */
+const prevUrl = computed(() => prev.value?.route);
+
+let tabBarList: TabBarItem[] = [];
+
+let isInited = false;
+
+function initIfNotInited() {
+  if (isInited) {
+    return;
+  }
+
+  uni.addInterceptor('navigateTo', { complete: refreshCurrentPages });
+  uni.addInterceptor('redirectTo', { complete: refreshCurrentPages });
+  uni.addInterceptor('reLaunch', { complete: refreshCurrentPages });
+  uni.addInterceptor('switchTab', { complete: refreshCurrentPages });
+  uni.addInterceptor('navigateBack', { complete: refreshCurrentPages });
+
+  refreshCurrentPages();
+
+  isInited = true;
+}
+
+function refreshCurrentPages() {
+  pages.value = getCurrentPages();
+}
+
+function warpPromiseOptions<T = any>(opts: T, resolve: (res: any) => any, reject: (err: any) => any) {
+  let { fail, success, complete } = opts as any;
+
+  fail = fail || ((err: any) => err);
+  success = success || ((res: any) => res);
+  complete = complete || (() => { });
+
+  return {
+    ...opts,
+    success: (res: any) => resolve(success(res)),
+    fail: (err: any) => reject(fail(err)),
+    complete,
+  };
+}
+
+/**
+ * 切换 tabbar 页面
+ */
+function switchTab(options: UniNamespace.SwitchTabOptions): Promise<any> {
+  return new Promise((resolve, reject) => {
+    uni.switchTab(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  })
+}
+
+function navigateTo(options: UniNamespace.NavigateToOptions) {
+  return new Promise((resolve, reject) => {
+    uni.navigateTo(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  });
+}
+
+function redirectTo(options: UniNamespace.RedirectToOptions) {
+  return new Promise((resolve, reject) => {
+    uni.redirectTo(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  });
+}
+
+/**
+ * 重定向，并清空当前页面栈
+ */
+function reLaunch(options: UniNamespace.ReLaunchOptions): Promise<any> {
+  return new Promise((resolve, reject) => {
+    uni.reLaunch(
+      warpPromiseOptions(options, resolve, reject),
+    );
+  });
+}
+
+/**
+ * 后退
+ */
+function back(options?: UniNamespace.NavigateBackOptions): Promise<any> {
+  return new Promise((resolve, reject) => {
+    uni.navigateBack(
+      warpPromiseOptions(options || {}, resolve, reject),
+    );
+  });
+}
+
+/**
+ * 路由跳转
+ * `tryTabBar = true` 时，自动判断是否 tabbar 页面
+ */
+function trySwitchTab<FN extends (typeof navigateTo | typeof redirectTo)>(tryTabBar: boolean, forward: FN, options: Parameters<FN>[0]): Promise<any> {
+  // 不尝试 tabbar 页面，直接跳转
+  if (!tryTabBar) {
+    return forward(options);
+  }
+
+  // 未设置 tabBarList，先尝试 switchTab，报错再尝试跳转
+  if (!tabBarList.length) {
+    return switchTab(options).catch(() => navigateTo(options));
+  }
+
+  const url = typeof options.url === 'string' ? options.url : options.url.toString();
+
+  // 如果是 tabBar 页面，则直接 switchTab
+  if (isTabBarPath(url)) {
+    return switchTab(options);
+  }
+
+  // 不是 tabBar，直接跳转
+  return navigateTo(options);
+}
+
+
+function isTabBarPath(path: string) {
+  const target = pathResolve(path);
+  const tabbar = tabBarList.find(t => `/${t.pagePath}` === target);
+  return !!tabbar;
+}
+
+type UniTabBarItem = Exclude<AppJson['tabBar'], undefined>['list'][number]
+
+type TabBarItem = RequiredOnly<UniTabBarItem, 'pagePath'>;
+
+export interface UseRouterOptions {
+  /**
+   * 是否尝试跳转 tabBar
+   * 开启后，使用 navigate / redirect 将会先尝试 tabBar
+   * @default true
+   */
+  tryTabBar?: boolean;
+  /**
+   * pages.json 里的 tabBar list 配置
+   * tryTabBar 开启时，会判断跳转页面
+   * 全局配置，仅需要配置一次
+   */
+  tabBarList?: TabBarItem[];
+}
+
+
+/**
+ * 路由操作的封装
+ * 
+ * UNIAPP 官方文档 @see https://uniapp.dcloud.net.cn/api/router.html
+ */
+export function useRouter(options: UseRouterOptions = {}) {
+  initIfNotInited();
+
+  const {
+    tryTabBar = true
+  } = options;
+
+  if (options.tabBarList) {
+    tabBarList = options.tabBarList;
+  }
+
+  /**
+   * 对实体按键 / 顶部导航栏返回按钮进行监听
+   * @see https://uniapp.dcloud.net.cn/tutorial/page.html#onbackpress
+   */
+  onBackPress((e) => {
+    if (e.from === 'navigateBack') return;
+    refreshCurrentPages();
+  });
+
+  /**
+   * 路由跳转
+   */
+  function navigate(options: UniNamespace.NavigateToOptions): Promise<any> {
+    return trySwitchTab(tryTabBar, navigateTo, options);
+  }
+
+  /**
+   * 路由重定向
+   */
+  function redirect(options: UniNamespace.RedirectToOptions): Promise<any> {
+    return trySwitchTab(tryTabBar, redirectTo, options);
+  }
+
 
   return {
     /** 获取当前页面栈信息 */
     pages,
     /** 获取当前页信息 */
-    page,
-    /** 获取前一页信息 */
-    prevPage,
+    current,
+    /** @deprecated 弃用，请使用 current */
+    page: current,
     /** 获取当前页路由信息 */
-    route,
+    currentUrl,
+    /** @deprecated 弃用，请使用 currentUrl */
+    route: currentUrl,
+    /** 获取前一页信息 */
+    prev,
+    /** @deprecated 弃用，请使用 prev */
+    prevPage: prev,
     /** 获取前一页路由信息 */
-    prevRoute,
+    prevUrl,
+    /** @deprecated 弃用，请使用 prevUrl */
+    prevRoute: prevUrl,
+    /** 切换 tabbar 页面。 */
+    switchTab,
+    /** 路由跳转 */
+    navigate,
+    /** 路由重定向 */
+    redirect,
+    /** 重定向，并清空当前页面栈 */
+    reLaunch,
+    /** 后退 */
+    back,
   };
 }

--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import { pathResolve } from 'src/utils';
+import { pathResolve } from '../utils';
 import type { AppJson } from '@dcloudio/uni-cli-shared'
 import type { RequiredOnly } from '../types'
 import { onBackPress } from '@dcloudio/uni-app';

--- a/src/useRouter/readme.md
+++ b/src/useRouter/readme.md
@@ -1,0 +1,43 @@
+# useRouter
+
+#### [返回首页](../../README.md)
+
+## 使用方式
+
+```ts
+import { tabBar } from '@/pages.json';
+
+const router = useRouter({
+  /**
+   * 是否尝试跳转 tabBar
+   * 开启后，使用 navigate / redirect 将会先尝试 tabBar
+   * @default true
+   */
+  tryTabBar: true;
+  /**
+   * pages.json 里的 tabBar list 配置
+   * tryTabBar 开启时，会判断跳转页面
+   * 全局配置，仅需要配置一次
+   */
+  tabBarList: tabBar.list;
+});
+
+// 如果上面的 tryTabBar 设定为 false，或非常确定是 tabbar 页面，可以直接使用 switchTab
+router.switchTab({ url: '/pages/tabbar/tabbar1' });
+
+// 路由跳转，参数和 uniapp 的一致
+// 当 tryTabBar = true 时，会自动判断 tabBar 页面进行跳转
+router.navigate({ url: '/pages/topics/index' });
+
+// 路由重定向，参数和 uniapp 的一致
+// 当 tryTabBar = true 时，会自动判断 tabBar 页面进行重定向
+router.redirect({ url: '/pages/auth/login' });
+
+// 路由重定向，并清空当前页面栈
+router.reLaunch({ url: '/pages/auth/login' });
+
+// 后退
+router.back();
+```
+
+#### [返回首页](../../README.md)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,3 +4,15 @@ export const isFunction = <T extends (...args: any[]) => any>(val: any): val is 
   typeof val === 'function';
 
 export const noop = () => {};
+
+export function pathResolve(target: string, current?: string) {
+  if (!current) {
+    const pages = getCurrentPages();
+    current = pages[pages.length - 1].route;
+  }
+
+  if (!current) {
+    throw new Error('The current path is undefined and cannot be found.');
+  }
+  return new URL(target, new URL(current, 'http://no-exists.com')).pathname;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ export const noop = () => {};
 export function pathResolve(target: string, current?: string) {
   if (!current) {
     const pages = getCurrentPages();
-    current = pages[pages.length - 1].route;
+    current = pages.length > 0 ? pages[pages.length - 1].route : undefined;
   }
 
   if (!current) {


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述
Reopen of #36 

1. 去除每次 useRouter 都新建对象的副作用。
2. 加入路由跳转的函数封装。无须再区分 tabbar 路由和页面路由。
3. 为了消歧义，将 page 和 route 改为 current 和 currentUrl
4. route 属性有歧义，容易误解为和vue router 一样的 route，但在uniapp里仅仅是个 url。（已添加 @deprecated 标识）

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues


### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced router utility for enhanced navigation within the mobile app.
	- Added new routing operations like switching tabs, navigating to pages, redirecting, and relaunching the app.
	- Implemented a method to navigate back within the app's navigation stack.

- **Documentation**
	- Updated `useRoute` documentation, recommending `useRouter().currentUrl` for current routing needs.

- **Refactor**
	- Deprecated certain properties in `useRouter` to streamline routing functionality.

- **Bug Fixes**
	- Fixed path resolution with new `pathResolve` function to improve navigation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->