### PR TITLE
fix: 修复 useStorage 因为生命周期无法正常响应问题

### DIFF
--- a/src/useStorage/index.ts
+++ b/src/useStorage/index.ts
@@ -1,9 +1,9 @@
-import { ref, shallowRef } from 'vue';
+import type { ConfigurableEventFilter, ConfigurableFlush, RemovableRef } from '@vueuse/core';
 import { resolveUnref, tryOnMounted, tryOnScopeDispose, watchWithFilter } from '@vueuse/core';
 import type { Ref } from 'vue';
-import type { ConfigurableEventFilter, ConfigurableFlush, RemovableRef } from '@vueuse/core';
-import { useInterceptor } from '../useInterceptor';
+import { ref, shallowRef } from 'vue';
 import type { MaybeComputedRef, MaybePromise } from '../types';
+import { useInterceptor } from '../useInterceptor';
 
 export interface UniStorageLike<T = any> {
   getItem: (options: UniNamespace.GetStorageOptions<T>) => MaybePromise<T>;
@@ -212,11 +212,11 @@ export function useStorage<T extends DataType>(
   }
 
   if (listenToStorageChanges) {
-    tryOnMounted(() => {
-      useInterceptor('setStorage', { complete: data.read });
-      useInterceptor('removeStorage', { complete: data.read });
-      useInterceptor('clearStorage', { complete: data.read });
+    useInterceptor('setStorage', { complete: data.read });
+    useInterceptor('removeStorage', { complete: data.read });
+    useInterceptor('clearStorage', { complete: data.read });
 
+    tryOnMounted(() => {
       if (initOnMounted) {
         data.read();
       }


### PR DESCRIPTION
### Description 描述

由于 onMounted 在页面内慢于onLoad，若在onLoad使用会因为没有完成拦截导致更改无法正常响应