### PR TITLE
新增 useRouter 对路由参数的支持

### DIFF
--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -195,12 +195,12 @@ export function useRouter(options: UseRouterOptions = {}) {
   }
 
   /** 路由跳转 */
-  function navigate(options: UniNamespace.NavigateToOptions): Promise<any> {
+  function navigate(options: NavigateToOptions): Promise<any> {
     return trySwitchTab(tryTabBar, navigateTo, options);
   }
 
   /** 路由重定向 */
-  function redirect(options: UniNamespace.RedirectToOptions): Promise<any> {
+  function redirect(options: RedirectToOptions): Promise<any> {
     return trySwitchTab(tryTabBar, redirectTo, options);
   }
 

--- a/src/useRouter/readme.md
+++ b/src/useRouter/readme.md
@@ -8,6 +8,7 @@
 
 ```ts
 import { useRouter } from '@uni-helper/uni-use';
+import { ref, watchEffect } from 'vue';
 import { tabBar } from '@/pages.json';
 
 const router = useRouter({
@@ -31,16 +32,33 @@ router.switchTab({ url: '/pages/tabbar/tabbar1' });
 // 路由跳转，参数和 uniapp 的一致
 // 当 tryTabBar = true 时，会自动判断 tabBar 页面进行跳转
 router.navigate({ url: '/pages/topics/index' });
+// 携带参数
+router.navigate({ url: '/pages/topics/index', params: { foo: 1 } });
 
 // 路由重定向，参数和 uniapp 的一致
 // 当 tryTabBar = true 时，会自动判断 tabBar 页面进行重定向
 router.redirect({ url: '/pages/auth/login' });
+// 携带参数
+router.navigate({ url: '/pages/auth/login', params: { bar: 'bar' } });
 
 // 路由重定向，并清空当前页面栈
 router.reLaunch({ url: '/pages/auth/login' });
 
 // 后退
 router.back();
+
+// 当前当前页路由参数
+const currentParams = router.currentParams;
+
+// 使用当前当前页路由参数获取数据
+const data = ref();
+
+watchEffect(async () => {
+  const response = await fetch(
+    `https://example.com/${currentParams.value.id}`
+  );
+  data.value = await response.json();
+});
 ```
 
 #### [返回列表](../readme.md)

--- a/src/useRouter/readme.md
+++ b/src/useRouter/readme.md
@@ -8,7 +8,7 @@
 
 ```ts
 import { useRouter } from '@uni-helper/uni-use';
-import { ref, watchEffect } from 'vue';
+import { computed, ref, watchEffect } from 'vue';
 import { tabBar } from '@/pages.json';
 
 const router = useRouter({
@@ -48,14 +48,14 @@ router.reLaunch({ url: '/pages/auth/login' });
 router.back();
 
 // 当前当前页路由参数
-const currentParams = router.currentParams;
+const id = computed(() => currentParams.value.id);
 
 // 使用当前当前页路由参数获取数据
 const data = ref();
 
 watchEffect(async () => {
   const response = await fetch(
-    `https://example.com/${currentParams.value.id}`
+    `https://example.com/${id}`
   );
   data.value = await response.json();
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getParams, setParams } from './utils';
+
+describe('useStorage', () => {
+  it('getParams', async () => {
+    expect(getParams('test?foo=1&bar=2')).toEqual({ foo: '1', bar: '2' });
+    expect(getParams('test?foo')).toEqual({ });
+    expect(getParams('test?foo&bar')).toEqual({ });
+    expect(getParams('test?')).toEqual({ });
+    expect(getParams()).toEqual({ });
+  });
+
+  it('setParams', async () => {
+    expect(setParams('test', { foo: '1', bar: '2' })).toEqual('test?foo=1&bar=2');
+    expect(setParams('test', { foo: undefined, bar: undefined })).toEqual('test');
+    expect(setParams('test', { foo: undefined, bar: null })).toEqual('test');
+    expect(setParams('test', { foo: undefined, bar: 0 })).toEqual('test?bar=0');
+    expect(setParams('test', { foo: undefined, bar: false })).toEqual('test?bar=false');
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,3 +63,60 @@ export function sleep(ms = 0) {
 export function isThenable(promise: any) {
   return typeof promise.then === 'function';
 }
+
+/**
+ * 获取 ? 后面的参数
+ * @param url - 可选的 URL 字符串，如果不提供则使用当前页面的 URL
+ * @returns 返回解析后的查询参数对象
+ */
+export function getParams<T extends Record<string, any>>(url?: string): T {
+  const _url = url || window.location.href;
+  const [, search] = _url.split('?');
+  if (search?.length) {
+    const paramsList = search.split('&');
+    const params = {} as T;
+    for (let index = 0; index < paramsList.length; index++) {
+      const item = paramsList[index];
+      if (!item) {
+        continue; // 检查每个参数对是否有效
+      }
+      const [key, value] = item.split('=');
+      if (key && value !== undefined && value !== '') {
+        // 将键值对添加到 params 对象中，并解码值
+        params[key as keyof T] = decodeURIComponent(value) as T[keyof T];
+      }
+    }
+    return params;
+  }
+  return {} as T;
+}
+
+/**
+ * 封装带有查询参数的 URL
+ * @param baseUrl - 基础 URL
+ * @param params - 要附加到 URL 的查询参数对象
+ * @returns 返回附加了查询参数的完整 URL
+ */
+export function setParams(baseUrl: string, params: Record<string, any>): string {
+  if (!Object.keys(params).length) {
+    return baseUrl;
+  }
+
+  let parameters = '';
+
+  for (const key in params) {
+    if (params[key] === undefined || params[key] === null || params[key] === '') {
+      continue;
+    } // 检查每个参数值是否有效
+    parameters += `${key}=${encodeURIComponent(params[key])}&`;
+  }
+
+  // 移除末尾多余的 '&' 并构建最终的 URL
+  parameters = parameters.replace(/&$/, '');
+  if (!parameters.length) {
+    return baseUrl;
+  }
+  return (/\?$/.test(baseUrl))
+    ? baseUrl + parameters
+    : baseUrl.replace(/\/?$/, '?') + parameters;
+}


### PR DESCRIPTION
### 描述
这个 PR 新增了类似 [vue router](https://router.vuejs.org/api/#LocationQueryRaw) 的 query 参数模式。

### 额外上下文
我明白这个模式不符合 `uni-app` 的默认跳转方式，但我习惯了 Vue 原生路由的参数传递方式，因此非常需要这个功能。它支持在路由跳转时携带参数，并在页面中获取这些参数。以下是一个使用示例：

```ts
import { useRouter } from '@uni-helper/uni-use';
import { ref, watchEffect } from 'vue';

const router = useRouter();

// 路由跳转，携带参数
router.navigate({ url: '/pages/topics/index', params: { foo: 1 } });

// 路由重定向，携带参数
router.navigate({ url: '/pages/auth/login', params: { bar: 'bar' } });

// 获取当前页路由参数
const id = computed(() => currentParams.value.id);

// 使用当前页路由参数获取数据
const data = ref();

watchEffect(async () => {
  const response = await fetch(
    `https://example.com/${id}`
  );
  data.value = await response.json();
});
```

尽管这个模式与 `uni-app` 的跳转机制有所冲突，但它极大地提高了我的开发效率。关于测试，由于单元测试不支持 `getCurrentPages`，目前尚未找到合适的解决方案，因此我只测试了 `utils` 中新增的函数。文档部分已根据新功能进行了相应修改。

请仔细审查这个 PR 的变更内容，如果可以，希望能够合并，因为这个功能对我的项目非常重要。

