### PR TITLE
feat: useRouter add query support

### DIFF
--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -3,7 +3,7 @@ import type { AppJson } from '@dcloudio/uni-cli-shared';
 import { computed, ref } from 'vue';
 import { tryOnBackPress } from '../tryOnBackPress';
 import { tryOnLoad } from '../tryOnLoad';
-import { pathResolve, setParams } from '../utils';
+import { pathResolve, setQuery } from '../utils';
 
 /** 获取当前页面栈信息 */
 const pages = ref<Page.PageInstance[]>([]);
@@ -87,33 +87,33 @@ function switchTab(options: UniNamespace.SwitchTabOptions): Promise<any> {
   });
 }
 interface NavigateToOptions extends UniNamespace.NavigateToOptions {
-  params?: Record<string, any>;
+  query?: Record<string, any>;
 }
 
 interface RedirectToOptions extends UniNamespace.RedirectToOptions {
-  params?: Record<string, any>;
+  query?: Record<string, any>;
 }
 
 /**
- * 处理 options.params
+ * 处理 options.query
  * @param options
  */
-function handleParams<T extends NavigateToOptions | RedirectToOptions>(options: T) {
-  if (options.params && typeof options.url === 'string') {
-    options.url = setParams(options.url, options.params);
-    options.params = undefined;
+function handleQuery<T extends NavigateToOptions | RedirectToOptions>(options: T) {
+  if (options.query && typeof options.url === 'string') {
+    options.url = setQuery(options.url, options.query);
+    options.query = undefined;
   }
   return options;
 }
 function navigateTo(options: NavigateToOptions) {
   return new Promise((resolve, reject) => {
-    uni.navigateTo(warpPromiseOptions(handleParams(options), resolve, reject));
+    uni.navigateTo(warpPromiseOptions(handleQuery(options), resolve, reject));
   });
 }
 
 function redirectTo(options: RedirectToOptions) {
   return new Promise((resolve, reject) => {
-    uni.redirectTo(warpPromiseOptions(handleParams(options), resolve, reject));
+    uni.redirectTo(warpPromiseOptions(handleQuery(options), resolve, reject));
   });
 }
 
@@ -193,10 +193,10 @@ export function useRouter(options: UseRouterOptions = {}) {
     tabBarList = options.tabBarList;
   }
 
-  const currentParams = ref<Record<string, any>>({});
+  const currentQuery = ref<Record<string, any>>({});
 
   tryOnLoad((options) => {
-    currentParams.value = options ?? {};
+    currentQuery.value = options ?? {};
   });
 
   /** 路由跳转 */
@@ -218,8 +218,8 @@ export function useRouter(options: UseRouterOptions = {}) {
     page: current,
     /** 获取当前页路由信息 */
     currentUrl,
-    /** 获取当前页params信息 */
-    currentParams,
+    /** 获取当前页query信息 */
+    currentQuery,
     /** @deprecated 弃用，请使用 currentUrl */
     route: currentUrl,
     /** 获取前一页信息 */

--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -101,7 +101,7 @@ interface RedirectToOptions extends UniNamespace.RedirectToOptions {
 function handleParams<T extends NavigateToOptions | RedirectToOptions>(options: T) {
   if (options.params && typeof options.url === 'string') {
     options.url = setParams(options.url, options.params);
-    delete options.params;
+    options.params = undefined;
   }
   return options;
 }

--- a/src/useRouter/index.ts
+++ b/src/useRouter/index.ts
@@ -100,8 +100,10 @@ interface RedirectToOptions extends UniNamespace.RedirectToOptions {
  */
 function handleQuery<T extends NavigateToOptions | RedirectToOptions>(options: T) {
   if (options.query && typeof options.url === 'string') {
-    options.url = setQuery(options.url, options.query);
-    options.query = undefined;
+    const _options = { ...options };
+    _options.url = setQuery(options.url, options.query);
+    _options.query = undefined;
+    return _options;
   }
   return options;
 }

--- a/src/useRouter/readme.md
+++ b/src/useRouter/readme.md
@@ -33,13 +33,13 @@ router.switchTab({ url: '/pages/tabbar/tabbar1' });
 // 当 tryTabBar = true 时，会自动判断 tabBar 页面进行跳转
 router.navigate({ url: '/pages/topics/index' });
 // 携带参数
-router.navigate({ url: '/pages/topics/index', params: { foo: 1 } });
+router.navigate({ url: '/pages/topics/index', query: { foo: 1 } });
 
 // 路由重定向，参数和 uniapp 的一致
 // 当 tryTabBar = true 时，会自动判断 tabBar 页面进行重定向
 router.redirect({ url: '/pages/auth/login' });
 // 携带参数
-router.navigate({ url: '/pages/auth/login', params: { bar: 'bar' } });
+router.navigate({ url: '/pages/auth/login', query: { bar: 'bar' } });
 
 // 路由重定向，并清空当前页面栈
 router.reLaunch({ url: '/pages/auth/login' });
@@ -48,7 +48,7 @@ router.reLaunch({ url: '/pages/auth/login' });
 router.back();
 
 // 当前当前页路由参数
-const id = computed(() => currentParams.value.id);
+const id = computed(() => router.currentQuery.value.id);
 
 // 使用当前当前页路由参数获取数据
 const data = ref();

--- a/src/useRouter/readme.md
+++ b/src/useRouter/readme.md
@@ -8,6 +8,7 @@
 
 ```ts
 import { useRouter } from '@uni-helper/uni-use';
+import { computed, ref, watchEffect } from 'vue';
 import { tabBar } from '@/pages.json';
 
 const router = useRouter({
@@ -31,16 +32,33 @@ router.switchTab({ url: '/pages/tabbar/tabbar1' });
 // 路由跳转，参数和 uniapp 的一致
 // 当 tryTabBar = true 时，会自动判断 tabBar 页面进行跳转
 router.navigate({ url: '/pages/topics/index' });
+// 携带参数
+router.navigate({ url: '/pages/topics/index', params: { foo: 1 } });
 
 // 路由重定向，参数和 uniapp 的一致
 // 当 tryTabBar = true 时，会自动判断 tabBar 页面进行重定向
 router.redirect({ url: '/pages/auth/login' });
+// 携带参数
+router.navigate({ url: '/pages/auth/login', params: { bar: 'bar' } });
 
 // 路由重定向，并清空当前页面栈
 router.reLaunch({ url: '/pages/auth/login' });
 
 // 后退
 router.back();
+
+// 当前当前页路由参数
+const id = computed(() => currentParams.value.id);
+
+// 使用当前当前页路由参数获取数据
+const data = ref();
+
+watchEffect(async () => {
+  const response = await fetch(
+    `https://example.com/${id}`
+  );
+  data.value = await response.json();
+});
 ```
 
 #### [返回列表](../readme.md)

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { setParams } from './utils';
+import { setQuery } from './utils';
 
 describe('useStorage', () => {
   it('setParams', async () => {
-    expect(setParams('test', { foo: '1', bar: '2' })).toEqual('test?foo=1&bar=2');
-    expect(setParams('test', { foo: undefined, bar: undefined })).toEqual('test');
-    expect(setParams('test', { foo: undefined, bar: null })).toEqual('test');
-    expect(setParams('test', { foo: undefined, bar: 0 })).toEqual('test?bar=0');
-    expect(setParams('test', { foo: undefined, bar: false })).toEqual('test?bar=false');
+    expect(setQuery('test', { foo: '1', bar: '2' })).toEqual('test?foo=1&bar=2');
+    expect(setQuery('test', { foo: undefined, bar: undefined })).toEqual('test');
+    expect(setQuery('test', { foo: undefined, bar: null })).toEqual('test');
+    expect(setQuery('test', { foo: undefined, bar: 0 })).toEqual('test?bar=0');
+    expect(setQuery('test', { foo: undefined, bar: false })).toEqual('test?bar=false');
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { setParams } from './utils';
+
+describe('useStorage', () => {
+  it('setParams', async () => {
+    expect(setParams('test', { foo: '1', bar: '2' })).toEqual('test?foo=1&bar=2');
+    expect(setParams('test', { foo: undefined, bar: undefined })).toEqual('test');
+    expect(setParams('test', { foo: undefined, bar: null })).toEqual('test');
+    expect(setParams('test', { foo: undefined, bar: 0 })).toEqual('test?bar=0');
+    expect(setParams('test', { foo: undefined, bar: false })).toEqual('test?bar=false');
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,21 +67,21 @@ export function isThenable(promise: any) {
 /**
  * 封装带有查询参数的 URL
  * @param baseUrl - 基础 URL
- * @param params - 要附加到 URL 的查询参数对象
+ * @param query - 要附加到 URL 的查询参数对象
  * @returns 返回附加了查询参数的完整 URL
  */
-export function setParams(baseUrl: string, params: Record<string, any>): string {
-  if (!Object.keys(params).length) {
+export function setQuery(baseUrl: string, query: Record<string, any>): string {
+  if (!Object.keys(query).length) {
     return baseUrl;
   }
 
   let parameters = '';
 
-  for (const key in params) {
-    if (params[key] === undefined || params[key] === null || params[key] === '') {
+  for (const key in query) {
+    if (query[key] === undefined || query[key] === null || query[key] === '') {
       continue;
     } // 检查每个参数值是否有效
-    parameters += `${key}=${encodeURIComponent(params[key])}&`;
+    parameters += `${key}=${encodeURIComponent(query[key])}&`;
   }
 
   // 移除末尾多余的 '&' 并构建最终的 URL

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,3 +63,33 @@ export function sleep(ms = 0) {
 export function isThenable(promise: any) {
   return typeof promise.then === 'function';
 }
+
+/**
+ * 封装带有查询参数的 URL
+ * @param baseUrl - 基础 URL
+ * @param params - 要附加到 URL 的查询参数对象
+ * @returns 返回附加了查询参数的完整 URL
+ */
+export function setParams(baseUrl: string, params: Record<string, any>): string {
+  if (!Object.keys(params).length) {
+    return baseUrl;
+  }
+
+  let parameters = '';
+
+  for (const key in params) {
+    if (params[key] === undefined || params[key] === null || params[key] === '') {
+      continue;
+    } // 检查每个参数值是否有效
+    parameters += `${key}=${encodeURIComponent(params[key])}&`;
+  }
+
+  // 移除末尾多余的 '&' 并构建最终的 URL
+  parameters = parameters.replace(/&$/, '');
+  if (!parameters.length) {
+    return baseUrl;
+  }
+  return (/\?$/.test(baseUrl))
+    ? baseUrl + parameters
+    : baseUrl.replace(/\/?$/, '?') + parameters;
+}


### PR DESCRIPTION
### 描述
这个 PR 新增了 [vue router](https://router.vuejs.org/api/#LocationQueryRaw) 的 query 参数模式。

### 额外上下文
我明白这个模式不符合 `uni-app` 的默认跳转方式，但我习惯了 Vue 原生路由的参数传递方式，因此非常需要这个功能。它支持在路由跳转时携带参数，并在页面中获取这些参数。以下是一个使用示例：

```ts
import { useRouter } from '@uni-helper/uni-use';
import { computed, ref, watchEffect } from 'vue';

const router = useRouter();

// 路由跳转，携带参数
router.navigate({ url: '/pages/topics/index', query: { foo: 1 } });

// 路由重定向，携带参数
router.navigate({ url: '/pages/auth/login', query: { bar: 'bar' } });

// 获取当前页路由参数
const id = computed(() => router.currentQuery.value.id);

// 使用当前页路由参数获取数据
const data = ref();

watchEffect(async () => {
  const response = await fetch(
    `https://example.com/${id}`
  );
  data.value = await response.json();
});
```

尽管这个模式与 `uni-app` 的跳转机制有所冲突，但它极大地提高了我的开发效率。关于测试，由于单元测试不支持 `getCurrentPages`，目前尚未找到合适的解决方案，因此我只测试了 `utils` 中新增的函数。文档部分已根据新功能进行了相应修改。

请仔细审查这个 PR 的变更内容，如果可以，希望能够合并，因为这个功能对我的项目非常重要。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced routing functionality with support for query parameters in navigation options.
	- Introduced a new utility for constructing URLs with query parameters.

- **Bug Fixes**
	- Improved handling of undefined, null, and falsy values in URL parameter construction.

- **Tests**
	- Added a test suite to validate the new query parameter handling functionality.

- **Documentation**
	- Updated documentation to reflect new routing capabilities and examples for using query parameters in navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->